### PR TITLE
Added get/setMaxFieldSize to Statement object

### DIFF
--- a/lib/statement.js
+++ b/lib/statement.js
@@ -178,6 +178,26 @@ Statement.prototype.getGeneratedKeys = function(callback) {
   });
 };
 
+Statement.prototype.getMaxFieldSize = function (callback) {
+  this._s.getMaxFieldSize(function (err, maxFieldSize) {
+    if (err) {
+      return callback(err);
+    } else {
+      return callback(null, maxFieldSize);
+    }
+  });
+};
+
+Statement.prototype.setMaxFieldSize = function (max, callback) {
+  this._s.setMaxFieldSize(max, function (err) {
+    if (err) {
+      return callback(err);
+    } else {
+      return callback(null);
+    }
+  });
+};
+
 jinst.events.once('initialized', function onInitialized() {
   // The constant indicating that the current ResultSet object should be closed
   // when calling getMoreResults.


### PR DESCRIPTION
`get/setMaxFieldSize` methods are required to prevent errors like
```
java.sql.SQLException: [NetSuite][SuiteAnalytics Connect JDBC Driver][OpenAccess SDK SQL Engine]Disk cache error. Field length:80368 exceeds maximum limit of 65535.[10232]
```
`setMaxFieldSize` can be used to set max field size to zero, this way driver will pass all data as is